### PR TITLE
Fix feature specs on Github CI

### DIFF
--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_08_200314) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_08_200314) do
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
     t.string "file_name"


### PR DESCRIPTION
One migration failed, because the migration for Rails 8.0 are not supported with Rails 7.2. Try to use a lower migration definition to fix this.