### PR TITLE
Fix Mission Control Jobs requirement

### DIFF
--- a/lib/alchemy/mission_control/jobs.rb
+++ b/lib/alchemy/mission_control/jobs.rb
@@ -1,10 +1,10 @@
 require "alchemy/mission_control/jobs/version"
 require "alchemy/mission_control/jobs/engine"
+require "mission_control/jobs"
 
 module Alchemy
   module MissionControl
     module Jobs
-      # Your code goes here...
     end
   end
 end


### PR DESCRIPTION
The gem wasn't required and Zeitwerk will not autoload the gem, if it is not in the application Gemfile.