### PR TITLE
Add changelog generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,4 @@ gem "rails", "~> #{rails_version}.0"
 gem "solid_queue"
 
 gem "standard", "~> 1.44"
+gem "github_changelog_generator", require: false

--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ Add the gem to your Gemfile and restart the application.
 $ bundle add alchemy-mission_control-jobs
 ```
 
+## Release a new version
+
+First, generate the changelog entries. Set the version parameter with the upcoming version number.
+
+```shell
+VERSION=x.y.z rake changelog
+```
+
+

--- a/Rakefile
+++ b/Rakefile
@@ -15,3 +15,23 @@ namespace :spec do
     system "cd spec/dummy; RAILS_ENV=test bin/rake db:setup db:seed; cd -"
   end
 end
+
+# add changelog task
+require "github_changelog_generator/task"
+
+# Temporary fix for SSL error
+# Ref: https://github.com/ruby/openssl/issues/949#issuecomment-3367944960
+require "openssl"
+s = OpenSSL::X509::Store.new.tap(&:set_default_paths)
+begin
+  OpenSSL::SSL::SSLContext.send(:remove_const, :DEFAULT_CERT_STORE)
+rescue
+  nil
+end
+OpenSSL::SSL::SSLContext.const_set(:DEFAULT_CERT_STORE, s.freeze)
+
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.user = "sitediver"
+  config.project = "alchemy-mission_control-jobs"
+  config.future_release = ENV["VERSION"]
+end


### PR DESCRIPTION
- add Github changelog generator gem to Gemfile. This gem is only used in development to easier generate changelogs.
- add a small release section to README to have a step by step decription how to release a new gem version