### PR TITLE
Try another approach to get the release workflow running

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,12 @@
 name: Release
 
 on:
-  release:
-    types: [ prereleased, released ]
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: read
 
 jobs:
   push:


### PR DESCRIPTION
Use the tag trigger instead of the release trigger.

Ref: https://github.com/segiddins/rubygems-await/blob/main/.github/workflows/push_gem.yml