### PR TITLE
Try to get the release workflow up and running

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - '*'
-
-permissions:
-  contents: read
+  release:
+    types: [ prereleased, released ]
 
 jobs:
   push:
@@ -22,6 +18,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+          fetch-tags: true
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
The release gem action does not fetch the tags, so it is necessary to check them out.

Ref: https://github.com/rubygems/release-gem/pull/17#issuecomment-2888949843