### PR TITLE
Remove the version env from changelog rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ gem bump --version minor
 Second, generate the changelog entries. Set the version parameter with the upcoming version number.
 
 ```shell
-VERSION=x.y.z rake changelog
+rake changelog
 ```
 
 Amend that changelog into the previous commit. After that go to [Releases Page](https://github.com/sitediver/alchemy-mission_control-jobs/releases)

--- a/Rakefile
+++ b/Rakefile
@@ -33,5 +33,5 @@ OpenSSL::SSL::SSLContext.const_set(:DEFAULT_CERT_STORE, s.freeze)
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|
   config.user = "sitediver"
   config.project = "alchemy-mission_control-jobs"
-  config.future_release = ENV["VERSION"]
+  config.future_release = "v#{Alchemy::MissionControl::Jobs::VERSION}"
 end


### PR DESCRIPTION
It is now using the version that will be bumped in the commit before the changelog generation.