### PR TITLE
Support dark theme in Alchemy 8

### DIFF
--- a/app/assets/stylesheets/alchemy/mission_control/jobs/mission-control.css
+++ b/app/assets/stylesheets/alchemy/mission_control/jobs/mission-control.css
@@ -1,5 +1,5 @@
 :root {
-    --bulma-scheme-main: var(--color-grey_light);
+    --bulma-scheme-main: var(--body-background-color, var(--color-grey_light));
 }
 
 main {

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -10,6 +10,7 @@
 
   <%= stylesheet_link_tag "mission_control/jobs/bulma.min" %>
   <%= stylesheet_link_tag "mission_control/jobs/application", "data-turbo-track": "reload" %>
+  <%= stylesheet_link_tag "alchemy/theme", "data-turbo-track": "reload" if Alchemy::VERSION.start_with?("8.") %>
   <%= stylesheet_link_tag "alchemy/mission_control/jobs/mission-control", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags "application", importmap: MissionControl::Jobs.importmap %>
 </head>


### PR DESCRIPTION
Add alchemy theme definition to application layout of the mission_control backend. This allows the usage of a new background-color custom property. The fallback will be still the default light grey color.