### PR TITLE
Allow Alchemy 8.1 and Rails 8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
           - alchemy_cms: "8.0"
             rails: "8.0"
             ruby: "3.4"
+          - alchemy_cms: "8.1"
+            rails: "8.1"
+            ruby: "3.4"
     env:
       RAILS_VERSION: ${{ matrix.rails }}
       ALCHEMY_CMS_VERSION: ${{ matrix.alchemy_cms }}

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,13 @@ source "https://rubygems.org"
 gem "puma"
 gem "sqlite3"
 
-alchemy_cms_version = ENV.fetch("ALCHEMY_CMS_VERSION", "8.0")
-if alchemy_cms_version == "8.0"
-  gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: "8.0-stable"
-  gem "alchemy-devise", github: "AlchemyCMS/alchemy-devise", branch: "main"
+alchemy_cms_version = ENV.fetch("ALCHEMY_CMS_VERSION", "8.1")
+if alchemy_cms_version.start_with?("8.")
   gem "propshaft"
+end
+if alchemy_cms_version == "8.1"
+  gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: "8.1-stable"
+  gem "alchemy-devise", github: "AlchemyCMS/alchemy-devise", branch: "main"
 else
   gem "alchemy_cms", "~> #{alchemy_cms_version}"
   gem "alchemy-devise", "~> #{alchemy_cms_version}"

--- a/alchemy-mission_control-jobs.gemspec
+++ b/alchemy-mission_control-jobs.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails", ">= 7.2.0", "< 8.1"
-  spec.add_dependency "alchemy_cms", ">= 7.4.0", "< 8.1"
+  spec.add_dependency "rails", ">= 7.2.0", "< 9.0"
+  spec.add_dependency "alchemy_cms", ">= 7.4.0", "< 8.2"
   spec.add_dependency "mission_control-jobs", ">= 1.0", "< 2.0"
 
   spec.add_development_dependency "capybara", ["~> 3.0"]


### PR DESCRIPTION
Prepare for the Alchemy 8.1 release, that is also allowing Rails 8.1.