### PR TITLE
Allow AlchemyCMS v8.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
           - alchemy_cms: "8.1"
             rails: "8.1"
             ruby: "3.4"
+          - alchemy_cms: "8.2"
+            rails: "8.1"
+            ruby: "3.4"
     env:
       RAILS_VERSION: ${{ matrix.rails }}
       ALCHEMY_CMS_VERSION: ${{ matrix.alchemy_cms }}

--- a/Gemfile
+++ b/Gemfile
@@ -7,13 +7,10 @@ alchemy_cms_version = ENV.fetch("ALCHEMY_CMS_VERSION", "8.1")
 if alchemy_cms_version.start_with?("8.")
   gem "propshaft"
 end
-if alchemy_cms_version == "8.1"
-  gem "alchemy_cms", github: "AlchemyCMS/alchemy_cms", branch: "8.1-stable"
-  gem "alchemy-devise", github: "AlchemyCMS/alchemy-devise", branch: "main"
-else
-  gem "alchemy_cms", "~> #{alchemy_cms_version}"
-  gem "alchemy-devise", "~> #{alchemy_cms_version}"
-end
+
+gem "alchemy_cms", "~> #{alchemy_cms_version}"
+devise_version = (Gem::Version.new(alchemy_cms_version) >= Gem::Version.new("8.0")) ? "8.0" : alchemy_cms_version
+gem "alchemy-devise", "~> #{devise_version}"
 
 # Specify your gem's dependencies in alchemy-mission_control-jobs.gemspec.
 gemspec

--- a/alchemy-mission_control-jobs.gemspec
+++ b/alchemy-mission_control-jobs.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 7.2.0", "< 9.0"
-  spec.add_dependency "alchemy_cms", ">= 7.4.0", "< 8.2"
+  spec.add_dependency "alchemy_cms", ">= 7.4.0", "< 9.0"
   spec.add_dependency "mission_control-jobs", ">= 1.0", "< 2.0"
 
   spec.add_development_dependency "capybara", ["~> 3.0"]


### PR DESCRIPTION
AlchemyCMS v8.2.0 was released a few hours ago. So let's support it.