### PR TITLE
Add missing migrations to dummy app

### DIFF
--- a/spec/dummy/db/migrate/20260510132030_create_active_storage_tables.active_storage.rb
+++ b/spec/dummy/db/migrate/20260510132030_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,58 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string :key, null: false
+      t.string :filename, null: false
+      t.string :content_type
+      t.text :metadata
+      t.string :service_name, null: false
+      t.bigint :byte_size, null: false
+      t.string :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [:key], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string :name, null: false
+      t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob, null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [:record_type, :record_id, :name, :blob_id], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [:blob_id, :variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
+end

--- a/spec/dummy/db/migrate/20260510132031_create_action_mailbox_tables.action_mailbox.rb
+++ b/spec/dummy/db/migrate/20260510132031_create_action_mailbox_tables.action_mailbox.rb
@@ -1,0 +1,21 @@
+# This migration comes from action_mailbox (originally 20180917164000)
+class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :action_mailbox_inbound_emails, id: primary_key_type do |t|
+      t.integer :status, default: 0, null: false
+      t.string :message_id, null: false
+      t.string :message_checksum, null: false
+
+      t.timestamps
+
+      t.index [:message_id, :message_checksum], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
+    end
+  end
+
+  private
+
+  def primary_key_type
+    config = Rails.configuration.generators
+    config.options[config.orm][:primary_key_type] || :primary_key
+  end
+end

--- a/spec/dummy/db/migrate/20260510132032_create_action_text_tables.action_text.rb
+++ b/spec/dummy/db/migrate/20260510132032_create_action_text_tables.action_text.rb
@@ -1,0 +1,27 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :action_text_rich_texts, id: primary_key_type do |t|
+      t.string :name, null: false
+      t.text :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
+
+      t.timestamps
+
+      t.index [:record_type, :record_id, :name], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
+end

--- a/spec/dummy/db/migrate/20260510132033_convert_select_value_for_multiple.alchemy.rb
+++ b/spec/dummy/db/migrate/20260510132033_convert_select_value_for_multiple.alchemy.rb
@@ -1,0 +1,12 @@
+# This migration comes from alchemy (originally 20251106150010)
+class ConvertSelectValueForMultiple < ActiveRecord::Migration[7.1]
+  def up
+    say_with_time "Converting Alchemy::Ingredients::Select values to multiple" do
+      update <<-SQL.squish
+        UPDATE alchemy_ingredients
+        SET value = '["' || value || '"]'
+        WHERE type = 'Alchemy::Ingredients::Select' AND value NOT LIKE '["%"]';
+      SQL
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20260510132034_add_metadata_to_page_versions.alchemy.rb
+++ b/spec/dummy/db/migrate/20260510132034_add_metadata_to_page_versions.alchemy.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# This migration comes from alchemy (originally 20260102121232)
+class AddMetadataToPageVersions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :alchemy_page_versions, :title, :string
+    add_column :alchemy_page_versions, :meta_description, :text
+    add_column :alchemy_page_versions, :meta_keywords, :text
+  end
+end

--- a/spec/dummy/db/migrate/20260510132035_add_publication_timestamps_to_alchemy_elements.alchemy.rb
+++ b/spec/dummy/db/migrate/20260510132035_add_publication_timestamps_to_alchemy_elements.alchemy.rb
@@ -1,0 +1,31 @@
+# This migration comes from alchemy (originally 20260115164704)
+class AddPublicationTimestampsToAlchemyElements < ActiveRecord::Migration[7.2]
+  def up
+    add_column :alchemy_elements, :public_on, :datetime
+    add_column :alchemy_elements, :public_until, :datetime
+
+    say_with_time "Populating publication dates" do
+      update <<-SQL.squish
+        UPDATE alchemy_elements
+        SET public_on = created_at
+        WHERE public = #{connection.quoted_true}
+      SQL
+    end
+  end
+
+  def down
+    say_with_time "Reverting publication dates" do
+      update <<-SQL.squish
+        UPDATE alchemy_elements
+        SET public = CASE
+          WHEN public_on IS NOT NULL AND public_on <= CURRENT_TIMESTAMP
+          THEN #{connection.quoted_true}
+          ELSE #{connection.quoted_false}
+        END
+      SQL
+    end
+
+    remove_column :alchemy_elements, :public_until
+    remove_column :alchemy_elements, :public_on
+  end
+end

--- a/spec/dummy/db/migrate/20260510132036_add_index_to_element_publication_timestamps.alchemy.rb
+++ b/spec/dummy/db/migrate/20260510132036_add_index_to_element_publication_timestamps.alchemy.rb
@@ -1,0 +1,14 @@
+# This migration comes from alchemy (originally 20260115164705)
+class AddIndexToElementPublicationTimestamps < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction! if connection.adapter_name.match?(/postgres/i)
+
+  def change
+    add_index :alchemy_elements, [:public_on, :public_until], algorithm: algorithm
+  end
+
+  private
+
+  def algorithm
+    connection.adapter_name.match?(/postgres/i) ? :concurrently : nil
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,54 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_10_125132) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_10_132036) do
+  create_table "action_mailbox_inbound_emails", force: :cascade do |t|
+    t.integer "status", default: 0, null: false
+    t.string "message_id", null: false
+    t.string "message_checksum", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["message_id", "message_checksum"], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
+  end
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "alchemy_attachments", force: :cascade do |t|
     t.string "name"
     t.string "file_name"
@@ -40,11 +87,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_10_125132) do
     t.integer "parent_element_id"
     t.boolean "fixed", default: false, null: false
     t.integer "page_version_id", null: false
+    t.datetime "public_on"
+    t.datetime "public_until"
     t.index ["creator_id"], name: "index_alchemy_elements_on_creator_id"
     t.index ["fixed"], name: "index_alchemy_elements_on_fixed"
     t.index ["page_version_id", "parent_element_id"], name: "idx_alchemy_elements_on_page_version_id_and_parent_element_id"
     t.index ["page_version_id", "position"], name: "idx_alchemy_elements_on_page_version_id_and_position"
     t.index ["page_version_id"], name: "index_alchemy_elements_on_page_version_id"
+    t.index ["public_on", "public_until"], name: "index_alchemy_elements_on_public_on_and_public_until"
     t.index ["updater_id"], name: "index_alchemy_elements_on_updater_id"
   end
 
@@ -147,6 +197,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_10_125132) do
     t.datetime "public_until", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "title"
+    t.text "meta_description"
+    t.text "meta_keywords"
     t.index ["page_id"], name: "index_alchemy_page_versions_on_page_id"
     t.index ["public_on", "public_until"], name: "index_alchemy_page_versions_on_public_on_and_public_until"
   end
@@ -291,6 +344,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_10_125132) do
     t.index ["taggings_count"], name: "index_gutentag_tags_on_taggings_count"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "alchemy_elements", "alchemy_page_versions", column: "page_version_id", on_delete: :cascade
   add_foreign_key "alchemy_ingredients", "alchemy_elements", column: "element_id", on_delete: :cascade
   add_foreign_key "alchemy_languages", "alchemy_sites", column: "site_id"


### PR DESCRIPTION
Add missing Rails and Alchemy migrations to dummy app. Forgot that on the previous Alchemy 8.2 pull request.

Ref: https://github.com/sitediver/alchemy-mission_control-jobs/pull/24